### PR TITLE
Add profile marker check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -443,14 +443,18 @@ nvm_do_install() {
     if nvm_profile_is_bash_or_zsh "${NVM_PROFILE-}"; then
       BASH_OR_ZSH=true
     fi
-    if ! command grep -qc '/nvm.sh' "$NVM_PROFILE"; then
+    if command grep -qc '# nvm completions' "$NVM_PROFILE"; then
+      nvm_echo "=> Skipping nvm source string (found '# nvm completions' marker in ${NVM_PROFILE})"
+    elif ! command grep -qc '/nvm.sh' "$NVM_PROFILE"; then
       nvm_echo "=> Appending nvm source string to $NVM_PROFILE"
       command printf "${SOURCE_STR}" >> "$NVM_PROFILE"
     else
       nvm_echo "=> nvm source string already in ${NVM_PROFILE}"
     fi
     # shellcheck disable=SC2016
-    if ${BASH_OR_ZSH} && ! command grep -qc '$NVM_DIR/bash_completion' "$NVM_PROFILE"; then
+    if ${BASH_OR_ZSH} && command grep -qc '# nvm completions' "$NVM_PROFILE"; then
+      nvm_echo "=> Skipping bash_completion source string (found '# nvm completions' marker in ${NVM_PROFILE})"
+    elif ${BASH_OR_ZSH} && ! command grep -qc '$NVM_DIR/bash_completion' "$NVM_PROFILE"; then
       nvm_echo "=> Appending bash_completion source string to $NVM_PROFILE"
       command printf "$COMPLETION_STR" >> "$NVM_PROFILE"
     else

--- a/test/install_script/nvm_profile_skip_on_marker
+++ b/test/install_script/nvm_profile_skip_on_marker
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+# Load the install script functions
+NVM_ENV=testing \. ../../install.sh
+
+# Simple test to verify the marker check works
+echo "Testing profile marker check functionality"
+
+# Create a test profile with marker
+TEMP_PROFILE=$(mktemp)
+echo "# nvm completions" > "$TEMP_PROFILE"
+
+# Test that grep detects the marker
+if command grep -qc '# nvm completions' "$TEMP_PROFILE"; then
+  echo "Marker detection works"
+else
+  die "Failed to detect '# nvm completions' marker"
+fi
+
+# Test profile without marker
+TEMP_PROFILE2=$(mktemp)
+echo "# some other comment" > "$TEMP_PROFILE2"
+
+if command grep -qc '# nvm completions' "$TEMP_PROFILE2"; then
+  die "False positive: detected marker when it shouldn't exist"
+else
+  echo "Correctly reports no marker when absent"
+fi
+
+# Cleanup
+rm -f "$TEMP_PROFILE" "$TEMP_PROFILE2"
+
+echo "All tests passed!"


### PR DESCRIPTION
Allow users to prevent nvm from automatically updating their shell configuration files by adding '# nvm completions' comment. This follows the same pattern as bun where the presence of the marker indicates the user wants to manage the configuration manually.

When '# nvm completions' is found in .zshrc/.bashrc, the installer will skip adding nvm initialization code, giving users more control over their shell configuration.
